### PR TITLE
Feat/strapi query limit

### DIFF
--- a/backend/config/plugins.js
+++ b/backend/config/plugins.js
@@ -7,6 +7,7 @@ module.exports = ({ env }) => ({
       playgroundAlways: false,
       depthLimit: 7,
       amountLimit: 100,
+      defaultLimit: -1, // default do not paginate and return all results
       apolloServer: {
         tracing: false,
       },


### PR DESCRIPTION
#### TODO
- Built on top of #74 so should wait until merge and clean up

#### What does this PR do?
- Set the default query for all graphql queries to be unlimited (-1)

#### How should this be manually tested?
* View any page with more than 10 entries (e.g. FAQs)

#### Screenshots (optional)
![image](https://user-images.githubusercontent.com/10515065/187374457-30e16599-47e6-4420-ab8e-f46c7f398d42.png)
