### PR TITLE
wip: local dev upload workaround

### DIFF
--- a/scripts/src/commands/strapi/index.ts
+++ b/scripts/src/commands/strapi/index.ts
@@ -3,6 +3,7 @@ import { logProgramHelp } from "../../utils";
 import bootstrapCmd from "./bootstrap";
 import configExportCmd from "./configExport";
 import dataExportCmd from "./dataExport";
+import mediaUploadCmd from "./mediaUpload";
 import typesGenerateCmd from "./typesGenerate";
 
 /***************************************************************************************
@@ -15,6 +16,7 @@ program.description("Strapi management scripts");
 program.addCommand(bootstrapCmd);
 program.addCommand(configExportCmd);
 program.addCommand(dataExportCmd);
+program.addCommand(mediaUploadCmd);
 program.addCommand(typesGenerateCmd);
 
 export default program;

--- a/scripts/src/commands/strapi/mediaUpload.ts
+++ b/scripts/src/commands/strapi/mediaUpload.ts
@@ -1,0 +1,99 @@
+import { Command } from "commander";
+import { readdirSync } from "fs-extra";
+import path from "path";
+import type { Strapi } from "../../../../backend/node_modules/@strapi/strapi";
+import { PATHS } from "../../paths";
+import { logOutput } from "../../utils";
+import { arrayToHashmap } from "../../utils/object.utils";
+import { createStrapiInstance } from "./common";
+
+/***************************************************************************************
+ * CLI
+ * @example yarn
+ *************************************************************************************/
+interface IProgramOptions {
+  outDir: string;
+}
+const program = new Command("media:populate");
+export default program
+  .description("Populate strapi media with local uploads")
+  .action(async () => new MediaPopulate().run());
+
+/***************************************************************************************
+ * Main Methods
+ *************************************************************************************/
+class MediaPopulate {
+  app: Strapi;
+  entityName = "plugin::upload.file";
+  // https://github.dev/strapi/strapi/blob/main/packages/core/upload/server/services/upload.js
+  uploadService: any;
+  /**
+   * ...
+   * TODO - will only handle flat folder structure (not nested)
+   **/
+  public async run() {
+    // start app
+    this.app = await createStrapiInstance(true);
+    await this.app.start();
+
+    // List all custom db endpoints for export (e.g. api::members.members)
+    const dbFiles = await this.app.entityService.findMany(this.entityName);
+    this.uploadService = this.app.plugin("upload").service("upload");
+
+    const expectedFiles = readdirSync(PATHS.backendUploadsDir, { withFileTypes: true })
+      .filter((f) => f.isFile())
+      .map((f) => ({ hash: f.name, filepath: path.resolve(PATHS.backendUploadsDir, f.name) }));
+
+    const dbFilesHashmap = arrayToHashmap(dbFiles, "hash");
+    const localFilesHashmap = arrayToHashmap(expectedFiles, "hash");
+
+    const actions: any = { CREATE: [], DELETE: [] };
+
+    // Delete db files that should not exist or are thumbnails
+    for (const [key, value] of Object.entries(dbFilesHashmap)) {
+      if (!localFilesHashmap.hasOwnProperty(key)) {
+        actions.DELETE.push(value);
+      }
+    }
+    // Create db files that do not exist
+    for (const [key, value] of Object.entries(localFilesHashmap)) {
+      if (!dbFilesHashmap.hasOwnProperty(key)) {
+        actions.CREATE.push(value);
+      }
+    }
+    // await this.handleCreate(actions.CREATE);
+    // await this.handleDelete(actions.DELETE);
+
+    // Clear all thumbnails
+    this.app.stop();
+  }
+
+  private async handleCreate(entities: { hash: string; filepath: string }[]) {
+    // TODO - remove thumbnails and other compressed/optimised images
+    // these will be manage by next.js instead
+
+    for (const entity of entities) {
+      const { hash } = entity;
+      const extension = path.extname(hash);
+      const hashName = path.basename(hash, extension);
+      const unhashedName = hashName.split("_").slice(0, -1).join("_");
+      const name = unhashedName + extension;
+      const data = {
+        name: name,
+
+        alternativeText: name,
+        caption: name,
+
+        folder: null,
+      };
+      console.log("create", data);
+      // await this.app.entityService.create(this.entityName, { data }).catch((err) => console.log(err.details.errors));
+    }
+  }
+  private async handleDelete(entities: { id: number; formats: any }[]) {
+    console.log("delete", entities);
+    for (const entity of entities) {
+      await this.app.entityService.delete(this.entityName, entity.id);
+    }
+  }
+}

--- a/scripts/src/paths.ts
+++ b/scripts/src/paths.ts
@@ -2,6 +2,7 @@ import path from "path";
 
 const rootDir = path.resolve(__dirname, "../../");
 const backendDir = path.resolve(rootDir, "backend");
+const backendUploadsDir = path.resolve(backendDir, "public", "uploads");
 const docsDir = path.resolve(rootDir, "docs");
 const dataDir = path.resolve(rootDir, "data");
 const frontendDir = path.resolve(rootDir, "frontend");
@@ -12,6 +13,7 @@ const wpOutputDir = path.resolve(scriptsDir, "output");
 
 export const PATHS = {
   backendDir,
+  backendUploadsDir,
   dataDir,
   docsDir,
   frontendDir,

--- a/scripts/src/utils/object.utils.ts
+++ b/scripts/src/utils/object.utils.ts
@@ -1,0 +1,9 @@
+export function arrayToHashmap<T>(arr: T[], keyfield: keyof T): { [key: string]: T } {
+  const hashmap: { [key: string]: T } = {};
+  for (const el of arr) {
+    if (el.hasOwnProperty(keyfield)) {
+      hashmap[el[keyfield as any]] = el;
+    }
+  }
+  return hashmap;
+}


### PR DESCRIPTION
## TODO 
- Verify if approach possible to upload file and match meta (likely won't keep same db id, so possibly won't work)
- Consider alternative approach where scripts used to export tables as json directly (omitting some like admin_users, but including the `files` table), and then importing back in

#### What does this PR do?
- Add script to delete db entries of files not present in 
- WiP Add script to add db entries for local files matching expected format


#### How should this be manually tested?
* Please include the steps to be done inorder to setup and test this PR.

#### Screenshots (optional)