### PR TITLE
feat: donate content and footer

### DIFF
--- a/data/db/components_common_action_buttons.json
+++ b/data/db/components_common_action_buttons.json
@@ -31,7 +31,7 @@
   },
   {
     "id": 7,
-    "link": "#",
+    "link": "https://cafdonate.cafonline.org/19346",
     "text": "Donate Now"
   },
   {

--- a/data/db/donate_contents.json
+++ b/data/db/donate_contents.json
@@ -4,7 +4,7 @@
     "created_by_id": 1,
     "id": 1,
     "published_at": 1670959765786,
-    "updated_at": 1675636928656,
+    "updated_at": 1693267945912,
     "updated_by_id": 1
   }
 ]

--- a/frontend/components/common/actionButtons.tsx
+++ b/frontend/components/common/actionButtons.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import type { ComponentCommonActionButton } from "../../graphql/generated";
+import { ExternalLink } from "./externalLink";
 
 export const ActionButtonsComponent: React.FC<{ actionButtons: ComponentCommonActionButton[]; className?: string }> = ({
   actionButtons,
@@ -11,13 +12,22 @@ export const ActionButtonsComponent: React.FC<{ actionButtons: ComponentCommonAc
 
   return (
     <div data-testid="actionButtons" className={`flex gap-2 ${className}`}>
-      {actionButtons?.map(({ id, Link: ButtonLink, Text: ButtonText }, index) => (
-        <Link key={id} href={ButtonLink}>
-          <button className={`btn btn-${getButtonColor(index)}`} key={id}>
-            {ButtonText}
-          </button>
-        </Link>
-      ))}
+      {actionButtons?.map(({ id, Link: ButtonLink, Text: ButtonText }, index) => {
+        const isExternalLink = ButtonLink.startsWith("http");
+        return isExternalLink ? (
+          <ExternalLink key={id} href={ButtonLink}>
+            <button className={`btn btn-${getButtonColor(index)}`} key={id}>
+              {ButtonText}
+            </button>
+          </ExternalLink>
+        ) : (
+          <Link key={id} href={ButtonLink}>
+            <button className={`btn btn-${getButtonColor(index)}`} key={id}>
+              {ButtonText}
+            </button>
+          </Link>
+        );
+      })}
     </div>
   );
 };

--- a/frontend/components/common/externalLink.tsx
+++ b/frontend/components/common/externalLink.tsx
@@ -1,0 +1,15 @@
+/**
+ * Uses a simple anchor tag to open external link, default in new tab with noopener rel
+ * https://pointjupiter.com/what-noopener-noreferrer-nofollow-explained/
+ * */
+export const ExternalLink = ({
+  href = "",
+  download = false,
+  children,
+  target = "_blank",
+  rel = "noopener noreferrer",
+}) => (
+  <a href={href} target={target} download={download} rel={rel}>
+    {children}
+  </a>
+);

--- a/frontend/components/footer/sitemap.tsx
+++ b/frontend/components/footer/sitemap.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import Image from "next/image";
-import PageSection from "components/layout/pageSection";
 import Link from "next/link";
+import { FacebookIcon } from "react-share";
 
-import { FacebookIcon, LinkedinIcon } from "react-share";
+import { ExternalLink } from "components/common/externalLink";
+import PageSection from "components/layout/pageSection";
 
-const size = "20px";
+const size = "32px";
 
 const pageLinks = [
   {
@@ -37,36 +38,36 @@ const pageLinks = [
 
 const Sitemap = () => {
   return (
-    <PageSection fullwidth className="bg-base-300 py-8" data-cy="sitemap">
-      <div className="items-center p-4">
-        <div className="items-center flex flex-wrap">
+    <>
+      <PageSection fullwidth className="bg-base-300 py-16" data-testid="sitemap">
+        <div className="flex flex-wrap justify-between gap-x-24 gap-y-8">
           <Image src="/images/sami-logo-no-text.svg" alt="sitemap-logo" width={100} height={100}></Image>
-        </div>
 
-        <div className="flex flex-wrap gap-6">
-          {pageLinks.map(({ href, label, id }) => (
-            <li key={id} style={{ listStyleType: "none" }} className="font-medium">
-              <Link href={href}>{label}</Link>
-            </li>
-          ))}
-        </div>
-        <div>
-          <button type="submit" className="btn btn-secondary">
-            Donate
-          </button>
-        </div>
+          <div className="flex-1 m-auto">
+            <div className="flex flex-wrap gap-6 justify-between">
+              {pageLinks.map(({ href, label, id }) => (
+                <Link key={id} className="font-medium" href={href}>
+                  {label}
+                </Link>
+              ))}
+              <Link className="btn btn-secondary" href={"/donate"}>
+                Donate
+              </Link>
+            </div>
+          </div>
 
-        <div className="flex flex-wrap md:place-self-center md:justify-self-end gap-1">
-          Follow us:
-          <FacebookIcon size={size} />
-          <LinkedinIcon size={size} />
+          <div className="flex flex-wrap md:place-self-center md:justify-self-end gap-1">
+            Follow us
+            <ExternalLink href="https://www.facebook.com/supportingami">
+              <FacebookIcon size={size} />
+            </ExternalLink>
+          </div>
         </div>
-      </div>
-
-      <p className="flex items-center justify-center text-sm text-sky-600">
-        © Supporting African Maths Initiatives | Registered Charity #1161994{" "}
-      </p>
-    </PageSection>
+        <p className="-mb-8 mt-8 text-center text-sm text-sky-600">
+          © Supporting African Maths Initiatives | Registered Charity #1161994{" "}
+        </p>
+      </PageSection>
+    </>
   );
 };
 

--- a/frontend/components/layout/pageSection.tsx
+++ b/frontend/components/layout/pageSection.tsx
@@ -1,8 +1,8 @@
-const PageSection = ({ children, className = "", fullwidth = false }) => {
+const PageSection = ({ children, className = "", childClassName = "", fullwidth = false, ...props }) => {
   if (fullwidth) {
     return (
-      <div data-testid="pageSectionFullwidth" className={`${className}`}>
-        <div data-testid="pageSection" className={`container mx-auto `}>
+      <div data-testid={props["data-testid" || "props"]} className={`${className}`}>
+        <div data-testid="pageSection" className={`container mx-auto ${childClassName}`}>
           {children}
         </div>
       </div>

--- a/frontend/pages/donate.tsx
+++ b/frontend/pages/donate.tsx
@@ -3,20 +3,23 @@ import React from "react";
 import type { GetStaticPropsContext, InferGetStaticPropsType } from "next";
 import { serverQuery } from "lib/graphql";
 import { DonateContentDocument } from "../graphql/generated";
-import type { DonateContentQuery } from "../graphql/generated";
+import type { ComponentHomeMissionStatement, DonateContentQuery } from "../graphql/generated";
 import PageSection from "components/layout/pageSection";
-import { MissionStatementComponent } from "components/pages/home/missionStatement";
 import Image from "next/image";
 
-import CAFLogo from "public/images/Donate/caf-logo.png";
-import EFLogo from "public/images/Donate/easyfundraising.png";
-import AmazonLogo from "public/images/Donate/amazon-smile.png";
+// import CAFLogo from "public/images/Donate/caf-logo.png";
+// import EFLogo from "public/images/Donate/easyfundraising.png";
+// import AmazonLogo from "public/images/Donate/amazon-smile.png";
 import PAHLogo from "public/images/Donate/panafricanhub.png";
 import BDULogo from "public/images/Donate/BDU.png";
 import InnodemsLogo from "public/images/Donate/innodems.png";
 import LWFLogo from "public/images/Donate/LWF.png";
 import HausdorffLogo from "public/images/Donate/hausdorff.png";
 import IDEMSLogo from "public/images/Donate/idems-international.png";
+import { ImageHeadingContentLayout } from "components/layout/columns";
+import { HTMLContent } from "components/common/htmlContent";
+import { ActionButtonsComponent } from "components/common/actionButtons";
+import { getStrapiMedia } from "lib/media";
 
 export const getStaticProps = async ({}: GetStaticPropsContext) => {
   const res = await serverQuery<DonateContentQuery>(DonateContentDocument);
@@ -27,6 +30,31 @@ export const getStaticProps = async ({}: GetStaticPropsContext) => {
   };
 };
 
+export const DonateContentComponent: React.FC<ComponentHomeMissionStatement> = ({
+  ActionButtons,
+  Description,
+  Heading,
+  Image: UploadedImage,
+  Text,
+}) => (
+  <>
+    <ImageHeadingContentLayout
+      imageSide="right"
+      Heading={<h2 className="subtitle">{Heading}</h2>}
+      Image={
+        <Image src={getStrapiMedia(UploadedImage)} alt={"image"} fill placeholder="empty" className="object-cover" />
+      }
+      Content={
+        <>
+          <h3>{Text}</h3>
+          <HTMLContent className="mb-6">{Description}</HTMLContent>
+          {ActionButtons && <ActionButtonsComponent actionButtons={ActionButtons} className="mt-8" />}
+        </>
+      }
+    />
+  </>
+);
+
 const DonatePage = ({ content }: InferGetStaticPropsType<typeof getStaticProps>) => {
   return (
     <>
@@ -36,13 +64,14 @@ const DonatePage = ({ content }: InferGetStaticPropsType<typeof getStaticProps>)
       <>
         {content.DonateStatement && (
           <PageSection fullwidth className="py-16 bg-blue-50">
-            <MissionStatementComponent {...(content.DonateStatement as any)} />
+            <DonateContentComponent {...(content.DonateStatement as any)} />
           </PageSection>
         )}
         <PageSection fullwidth className="bg-primary-focus text-white py-0">
           <h3 className="text-center">You can help us make a difference - SUPPORT SAMI</h3>
         </PageSection>
-        <PageSection fullwidth className="py-16">
+        {/* TODO - CC 2023-08-29 - Confirm if still want custom section */}
+        {/* <PageSection fullwidth className="py-16">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
             <div className="px-2 mb-10">
               <h4 className="text-xl font-semibold">Donate Directly</h4>
@@ -70,8 +99,8 @@ const DonatePage = ({ content }: InferGetStaticPropsType<typeof getStaticProps>)
               </div>
             </div>
           </div>
-        </PageSection>
-        <PageSection fullwidth className="bg-blue-50 py-20 mt-6 mb-12">
+        </PageSection> */}
+        {/* <PageSection fullwidth className="bg-blue-50 py-20 mt-6 mb-12">
           <div className="grid grid-cols-1 lg:grid-cols-3 w-full gap-10">
             <div className="text-left">
               <h3>How we use your donation</h3>
@@ -86,7 +115,7 @@ const DonatePage = ({ content }: InferGetStaticPropsType<typeof getStaticProps>)
               Aenean faucibus nibh et justo cursus id rutrum lorem imperdiet.
             </div>
           </div>
-        </PageSection>
+        </PageSection> */}
         <PageSection className="mt-6 mb-12 text-center">
           <div>
             <div>


### PR DESCRIPTION
#### What does this PR do?

- Simplify donate page (focus only on CAF donate method)
- Add popup to `Donate Now` button
- Add support for generic `ExternalLink` component to open external links in new tab
- Tidy footer layout

#### How should this be manually tested?
- Already deployed to http://next.samicharity.co.uk
- Locally should import content `yarn scripts strapi import`

#### Screenshots
**Donate Page**
![image](https://github.com/supportingami/sami-website/assets/10515065/029fd3b0-da35-4ef1-8c89-bb2af4038fec)

**Donate popup (CAF)**
![image](https://github.com/supportingami/sami-website/assets/10515065/78793feb-ae41-4626-a053-9f52bee02719)
